### PR TITLE
chore: fix current errors in lambda

### DIFF
--- a/infra/terraform/lambda.tf
+++ b/infra/terraform/lambda.tf
@@ -41,7 +41,7 @@ resource "aws_lambda_function" "content_api" {
   function_name    = "bonae-content-api"
   role             = aws_iam_role.lambda_exec.arn
   handler          = "handler.handler"
-  runtime          = "nodejs20.x"
+  runtime          = "nodejs24.x"
   memory_size      = 256
   timeout          = 30
   source_code_hash = data.archive_file.lambda_zip.output_base64sha256

--- a/services/content-api/package.json
+++ b/services/content-api/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "build": "npm run build --prefix ../../packages/content && esbuild src/handler.ts --bundle --platform=node --target=node20 --outfile=dist/handler.js --format=esm && echo '{\"type\":\"module\"}' > dist/package.json"
+    "build": "npm run build --prefix ../../packages/content && esbuild src/handler.ts --bundle --platform=node --target=node24 --outfile=dist/handler.js --format=cjs"
   },
   "dependencies": {
     "@aws-sdk/client-secrets-manager": "^3.699.0",


### PR DESCRIPTION
What changed

| File | Change |
|-----|--------|
|services/content-api/package.json | CJS bundle (--format=cjs), target node24, removed ESM dist/package.json |
| infra/terraform/lambda.tf | Runtime nodejs20.x → nodejs24.x  |

The build was verified: when handler.js is zipped alone (as Lambda does), handler exports correctly. The earlier local require() test failed only because the parent package has "type": "module" — Lambda does not see that file.

```mermaid
flowchart TD
    PC["packages/content\n(build first)"]
    Static["apps/static"]
    Admin["apps/admin"]
    API["services/content-api\n→ Lambda zip"]

    PC --> Static
    PC --> Admin
    PC --> API
```