### PR TITLE
chore: updating token refresh mechanism

### DIFF
--- a/apps/admin/src/App.tsx
+++ b/apps/admin/src/App.tsx
@@ -1,59 +1,112 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { config, isConfigured } from './config.js';
-import { getCurrentSession, getSessionExpiresAt, signIn, signOut } from './infrastructure/auth.js';
-import { registerSessionExpiredHandler } from './infrastructure/contentApi.js';
+import {
+  confirmPasswordReset,
+  getCurrentSession,
+  getSessionExpiresAt,
+  refreshSession,
+  requestPasswordReset,
+  signIn,
+  signOut,
+  type LogoutReason,
+} from './infrastructure/auth.js';
+import { registerSessionExpiredHandler, registerSessionRefreshedHandler } from './infrastructure/contentApi.js';
+import { validatePassword } from './infrastructure/passwordPolicy.js';
 import { ConfigMissing } from './ui/ConfigMissing.js';
+import { ForgotPasswordForm } from './ui/ForgotPasswordForm.js';
 import { LoginForm } from './ui/LoginForm.js';
+import { ResetPasswordForm } from './ui/ResetPasswordForm.js';
 import { Dashboard } from './ui/Dashboard.js';
+
+type AuthView = 'login' | 'forgot' | 'reset';
+
+const SESSION_EXPIRED_MESSAGE = 'Your session expired. Please sign in again.';
+const SESSION_REFRESHED_MESSAGE = 'Your session was extended automatically.';
+const PASSWORD_RESET_SUCCESS_MESSAGE = 'Password updated. Sign in with your new password.';
 
 export default function App() {
   const [ready, setReady] = useState(false);
   const [authenticated, setAuthenticated] = useState(false);
+  const [authView, setAuthView] = useState<AuthView>('login');
+  const [resetEmail, setResetEmail] = useState('');
+  const [loginInfoMessage, setLoginInfoMessage] = useState<string | null>(null);
+  const [sessionMessage, setSessionMessage] = useState<string | null>(null);
   const [newPasswordChallenge, setNewPasswordChallenge] = useState<((pw: string) => Promise<void>) | null>(null);
   const logoutTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const handleLogout = useCallback(() => {
+  const clearLogoutTimer = useCallback(() => {
     if (logoutTimerRef.current) {
       clearTimeout(logoutTimerRef.current);
       logoutTimerRef.current = null;
     }
-    void signOut();
-    setAuthenticated(false);
   }, []);
 
-  const scheduleLogoutAt = useCallback(
-    async (expiresAt: number | null) => {
-      if (logoutTimerRef.current) {
-        clearTimeout(logoutTimerRef.current);
-        logoutTimerRef.current = null;
-      }
+  const handleLogout = useCallback((reason: LogoutReason = 'manual') => {
+    clearLogoutTimer();
+    void signOut();
+    setAuthenticated(false);
+    setAuthView('login');
+    setSessionMessage(null);
+    if (reason === 'expired') {
+      setLoginInfoMessage(SESSION_EXPIRED_MESSAGE);
+    } else {
+      setLoginInfoMessage(null);
+    }
+  }, [clearLogoutTimer]);
+
+  const scheduleSessionCheckAt = useCallback(
+    (expiresAt: number | null) => {
+      clearLogoutTimer();
       if (!expiresAt) return;
 
-      const delay = Math.max(0, expiresAt - Date.now() - 30_000);
+      const delay = Math.max(0, expiresAt - Date.now());
       logoutTimerRef.current = setTimeout(() => {
-        handleLogout();
+        void (async () => {
+          const session = await refreshSession();
+          if (session) {
+            const nextExpiresAt = await getSessionExpiresAt();
+            setSessionMessage(SESSION_REFRESHED_MESSAGE);
+            await scheduleSessionCheckAt(nextExpiresAt);
+            return;
+          }
+          handleLogout('expired');
+        })();
       }, delay);
     },
-    [handleLogout],
+    [clearLogoutTimer, handleLogout],
   );
 
   const checkSession = useCallback(async () => {
     const session = await getCurrentSession();
     if (!session?.isValid()) {
-      handleLogout();
+      handleLogout('expired');
       return;
     }
     const expiresAt = await getSessionExpiresAt();
     if (!expiresAt) {
-      handleLogout();
+      const refreshed = await refreshSession();
+      if (!refreshed) {
+        handleLogout('expired');
+        return;
+      }
+      const nextExpiresAt = await getSessionExpiresAt();
+      if (!nextExpiresAt) {
+        handleLogout('expired');
+        return;
+      }
+      setAuthenticated(true);
+      await scheduleSessionCheckAt(nextExpiresAt);
       return;
     }
     setAuthenticated(true);
-    await scheduleLogoutAt(expiresAt);
-  }, [handleLogout, scheduleLogoutAt]);
+    await scheduleSessionCheckAt(expiresAt);
+  }, [handleLogout, scheduleSessionCheckAt]);
 
   useEffect(() => {
     registerSessionExpiredHandler(handleLogout);
+    registerSessionRefreshedHandler(() => {
+      setSessionMessage(SESSION_REFRESHED_MESSAGE);
+    });
   }, [handleLogout]);
 
   useEffect(() => {
@@ -75,6 +128,13 @@ export default function App() {
     return () => document.removeEventListener('visibilitychange', onVisibilityChange);
   }, [authenticated, checkSession]);
 
+  async function completeLogin() {
+    setAuthenticated(true);
+    setLoginInfoMessage(null);
+    const expiresAt = await getSessionExpiresAt();
+    await scheduleSessionCheckAt(expiresAt);
+  }
+
   if (!isConfigured()) {
     return <ConfigMissing />;
   }
@@ -91,9 +151,7 @@ export default function App() {
           onSubmit={async (newPassword) => {
             await newPasswordChallenge(newPassword);
             setNewPasswordChallenge(null);
-            setAuthenticated(true);
-            const expiresAt = await getSessionExpiresAt();
-            await scheduleLogoutAt(expiresAt);
+            await completeLogin();
           }}
         />
       </>
@@ -101,20 +159,62 @@ export default function App() {
   }
 
   if (!authenticated) {
+    if (authView === 'forgot') {
+      return (
+        <>
+          {config.useMock && <MockModeBanner />}
+          <ForgotPasswordForm
+            onSubmit={requestPasswordReset}
+            onBack={() => {
+              setAuthView('login');
+              setLoginInfoMessage(null);
+            }}
+            onContinue={(email) => {
+              setResetEmail(email);
+              setAuthView('reset');
+            }}
+          />
+        </>
+      );
+    }
+
+    if (authView === 'reset') {
+      return (
+        <>
+          {config.useMock && <MockModeBanner />}
+          <ResetPasswordForm
+            email={resetEmail}
+            onSubmit={async (email, code, newPassword) => {
+              await confirmPasswordReset(email, code, newPassword);
+              setAuthView('login');
+              setLoginInfoMessage(PASSWORD_RESET_SUCCESS_MESSAGE);
+            }}
+            onBack={() => {
+              setAuthView('login');
+              setLoginInfoMessage(null);
+            }}
+          />
+        </>
+      );
+    }
+
     return (
       <>
         {config.useMock && <MockModeBanner />}
         <LoginForm
           mockMode={config.useMock}
+          infoMessage={loginInfoMessage}
           onLogin={async (email, password) => {
             const result = await signIn(email, password);
             if (result.type === 'success') {
-              setAuthenticated(true);
-              const expiresAt = await getSessionExpiresAt();
-              await scheduleLogoutAt(expiresAt);
+              await completeLogin();
             } else {
               setNewPasswordChallenge(() => result.completeChallenge);
             }
+          }}
+          onForgotPassword={() => {
+            setLoginInfoMessage(null);
+            setAuthView('forgot');
           }}
         />
       </>
@@ -124,7 +224,11 @@ export default function App() {
   return (
     <>
       {config.useMock && <MockModeBanner />}
-      <Dashboard onLogout={handleLogout} />
+      <Dashboard
+        onLogout={() => handleLogout('manual')}
+        sessionMessage={sessionMessage}
+        onDismissSessionMessage={() => setSessionMessage(null)}
+      />
     </>
   );
 }
@@ -149,6 +253,11 @@ function SetNewPasswordForm({ onSubmit }: { onSubmit: (newPassword: string) => P
       setError('Passwords do not match');
       return;
     }
+    const policyError = validatePassword(password);
+    if (policyError) {
+      setError(policyError);
+      return;
+    }
     setLoading(true);
     setError(null);
     try {
@@ -164,7 +273,7 @@ function SetNewPasswordForm({ onSubmit }: { onSubmit: (newPassword: string) => P
     <div className="flex min-h-screen items-center justify-center p-4">
       <form onSubmit={handleSubmit} className="card w-full max-w-md space-y-4">
         <h1 className="text-2xl font-bold text-slate-900">Set new password</h1>
-        <p className="text-sm text-slate-600">Your temporary password has expired. Please choose a permanent password.</p>
+        <p className="text-sm text-slate-600">Choose a permanent password to finish setting up your account.</p>
         {error && <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</p>}
         <div>
           <label className="field-label" htmlFor="new-password">New password</label>

--- a/apps/admin/src/infrastructure/auth.cognito.ts
+++ b/apps/admin/src/infrastructure/auth.cognito.ts
@@ -7,21 +7,36 @@ import {
 import { config } from '../config.js';
 import { SessionExpiredError } from './session.js';
 
-let sessionExpiredHandler: (() => void) | null = null;
+export type LogoutReason = 'expired' | 'manual';
 
-export function onSessionExpired(handler: () => void): void {
+let sessionExpiredHandler: ((reason: LogoutReason) => void) | null = null;
+let sessionRefreshedHandler: (() => void) | null = null;
+
+export function onSessionExpired(handler: (reason: LogoutReason) => void): void {
   sessionExpiredHandler = handler;
 }
 
-function notifySessionExpired(): void {
+export function onSessionRefreshed(handler: () => void): void {
+  sessionRefreshedHandler = handler;
+}
+
+function notifySessionExpired(reason: LogoutReason = 'expired'): void {
   signOut();
-  sessionExpiredHandler?.();
+  sessionExpiredHandler?.(reason);
+}
+
+function notifySessionRefreshed(): void {
+  sessionRefreshedHandler?.();
 }
 
 const pool = new CognitoUserPool({
   UserPoolId: config.userPoolId,
   ClientId: config.clientId,
 });
+
+function getPoolUser(): CognitoUser | null {
+  return pool.getCurrentUser();
+}
 
 export function signIn(
   email: string,
@@ -55,7 +70,7 @@ export function signOut(): void {
 }
 
 export function getCurrentSession(): Promise<CognitoUserSession | null> {
-  const user = pool.getCurrentUser();
+  const user = getPoolUser();
   if (!user) return Promise.resolve(null);
 
   return new Promise((resolve, reject) => {
@@ -71,8 +86,46 @@ export function isSessionExpired(session: CognitoUserSession): boolean {
   return exp * 1000 <= Date.now();
 }
 
+async function ensureValidSession(notifyOnRefresh: boolean): Promise<CognitoUserSession | null> {
+  let session: CognitoUserSession | null;
+  try {
+    session = await getCurrentSession();
+  } catch {
+    session = null;
+  }
+
+  const wasExpired = !session?.isValid() || (session !== null && isSessionExpired(session));
+
+  if (wasExpired) {
+    try {
+      session = await getCurrentSession();
+    } catch {
+      return null;
+    }
+  }
+
+  if (!session?.isValid() || isSessionExpired(session)) {
+    return null;
+  }
+
+  if (notifyOnRefresh && wasExpired) {
+    notifySessionRefreshed();
+  }
+
+  return session;
+}
+
+export async function refreshSession(): Promise<CognitoUserSession | null> {
+  return ensureValidSession(true);
+}
+
 export async function getSessionExpiresAt(): Promise<number | null> {
-  const session = await getCurrentSession();
+  let session: CognitoUserSession | null;
+  try {
+    session = await getCurrentSession();
+  } catch {
+    return null;
+  }
   if (!session?.isValid() || isSessionExpired(session)) {
     return null;
   }
@@ -80,10 +133,34 @@ export async function getSessionExpiresAt(): Promise<number | null> {
 }
 
 export async function getIdToken(): Promise<string> {
-  const session = await getCurrentSession();
-  if (!session?.isValid() || isSessionExpired(session)) {
-    notifySessionExpired();
+  const session = await ensureValidSession(false);
+
+  if (!session) {
+    notifySessionExpired('expired');
     throw new SessionExpiredError('Not authenticated');
   }
+
   return session.getIdToken().getJwtToken();
+}
+
+export function requestPasswordReset(email: string): Promise<void> {
+  const user = new CognitoUser({ Username: email.trim(), Pool: pool });
+
+  return new Promise((resolve, reject) => {
+    user.forgotPassword({
+      onSuccess: () => resolve(),
+      onFailure: (err) => reject(err),
+    });
+  });
+}
+
+export function confirmPasswordReset(email: string, code: string, newPassword: string): Promise<void> {
+  const user = new CognitoUser({ Username: email.trim(), Pool: pool });
+
+  return new Promise((resolve, reject) => {
+    user.confirmPassword(code.trim(), newPassword, {
+      onSuccess: () => resolve(),
+      onFailure: (err) => reject(err),
+    });
+  });
 }

--- a/apps/admin/src/infrastructure/auth.mock.ts
+++ b/apps/admin/src/infrastructure/auth.mock.ts
@@ -2,16 +2,29 @@ import { SessionExpiredError } from './session.js';
 
 const STORAGE_KEY = 'bonae-admin-mock-auth';
 const EXPIRY_KEY = 'bonae-admin-mock-exp';
+const RESET_EMAIL_KEY = 'bonae-admin-mock-reset-email';
+const MOCK_RESET_CODE = '123456';
 
-let sessionExpiredHandler: (() => void) | null = null;
+export type LogoutReason = 'expired' | 'manual';
 
-export function onSessionExpired(handler: () => void): void {
+let sessionExpiredHandler: ((reason: LogoutReason) => void) | null = null;
+let sessionRefreshedHandler: (() => void) | null = null;
+
+export function onSessionExpired(handler: (reason: LogoutReason) => void): void {
   sessionExpiredHandler = handler;
 }
 
-function notifySessionExpired(): void {
+export function onSessionRefreshed(handler: () => void): void {
+  sessionRefreshedHandler = handler;
+}
+
+function notifySessionExpired(reason: LogoutReason = 'expired'): void {
   signOut();
-  sessionExpiredHandler?.();
+  sessionExpiredHandler?.(reason);
+}
+
+function notifySessionRefreshed(): void {
+  sessionRefreshedHandler?.();
 }
 
 export interface MockSession {
@@ -41,10 +54,28 @@ export function getCurrentSession(): Promise<MockSession | null> {
   }
   const exp = Number(sessionStorage.getItem(EXPIRY_KEY) ?? '0');
   if (exp <= Date.now()) {
-    signOut();
-    return Promise.resolve(null);
+    return Promise.resolve({ isValid: () => false });
   }
   return Promise.resolve({ isValid: () => true });
+}
+
+export async function refreshSession(): Promise<MockSession | null> {
+  return ensureValidMockSession(true);
+}
+
+async function ensureValidMockSession(notifyOnRefresh: boolean): Promise<MockSession | null> {
+  if (!sessionStorage.getItem(STORAGE_KEY)) {
+    return null;
+  }
+  const exp = Number(sessionStorage.getItem(EXPIRY_KEY) ?? '0');
+  const wasExpired = exp <= Date.now();
+  if (wasExpired) {
+    sessionStorage.setItem(EXPIRY_KEY, String(Date.now() + 60 * 60 * 1000));
+    if (notifyOnRefresh) {
+      notifySessionRefreshed();
+    }
+  }
+  return { isValid: () => true };
 }
 
 export async function getSessionExpiresAt(): Promise<number | null> {
@@ -54,13 +85,33 @@ export async function getSessionExpiresAt(): Promise<number | null> {
 }
 
 export async function getIdToken(): Promise<string> {
-  if (!sessionStorage.getItem(STORAGE_KEY)) {
-    throw new SessionExpiredError('Not authenticated');
-  }
-  const exp = Number(sessionStorage.getItem(EXPIRY_KEY) ?? '0');
-  if (exp <= Date.now()) {
-    notifySessionExpired();
+  const session = await ensureValidMockSession(false);
+  if (!session?.isValid()) {
+    notifySessionExpired('expired');
     throw new SessionExpiredError('Not authenticated');
   }
   return 'mock-local-token';
+}
+
+export function requestPasswordReset(email: string): Promise<void> {
+  if (!email.trim()) {
+    return Promise.reject(new Error('Email is required'));
+  }
+  sessionStorage.setItem(RESET_EMAIL_KEY, email.trim());
+  return Promise.resolve();
+}
+
+export function confirmPasswordReset(email: string, code: string, newPassword: string): Promise<void> {
+  const storedEmail = sessionStorage.getItem(RESET_EMAIL_KEY);
+  if (!storedEmail || storedEmail !== email.trim()) {
+    return Promise.reject(new Error('Invalid verification code'));
+  }
+  if (code.trim() !== MOCK_RESET_CODE) {
+    return Promise.reject(new Error('Invalid verification code'));
+  }
+  if (!newPassword) {
+    return Promise.reject(new Error('Password is required'));
+  }
+  sessionStorage.removeItem(RESET_EMAIL_KEY);
+  return Promise.resolve();
 }

--- a/apps/admin/src/infrastructure/auth.ts
+++ b/apps/admin/src/infrastructure/auth.ts
@@ -4,6 +4,8 @@ export type SignInResult =
   | { type: 'success' }
   | { type: 'newPasswordRequired'; completeChallenge: (newPassword: string) => Promise<void> };
 
+export type LogoutReason = 'expired' | 'manual';
+
 type AuthModule = typeof import('./auth.mock.js');
 
 let authModule: AuthModule | null = null;
@@ -33,6 +35,14 @@ export async function getIdToken(): Promise<string> {
   return (await getAuth()).getIdToken();
 }
 
+export async function refreshSession() {
+  const auth = await getAuth();
+  if ('refreshSession' in auth && typeof auth.refreshSession === 'function') {
+    return auth.refreshSession();
+  }
+  return null;
+}
+
 export async function getSessionExpiresAt(): Promise<number | null> {
   const auth = await getAuth();
   if ('getSessionExpiresAt' in auth && typeof auth.getSessionExpiresAt === 'function') {
@@ -41,11 +51,34 @@ export async function getSessionExpiresAt(): Promise<number | null> {
   return null;
 }
 
-export async function onSessionExpired(handler: () => void): Promise<void> {
+export async function onSessionExpired(handler: (reason: LogoutReason) => void): Promise<void> {
   const auth = await getAuth();
   if ('onSessionExpired' in auth && typeof auth.onSessionExpired === 'function') {
     auth.onSessionExpired(handler);
   }
+}
+
+export async function onSessionRefreshed(handler: () => void): Promise<void> {
+  const auth = await getAuth();
+  if ('onSessionRefreshed' in auth && typeof auth.onSessionRefreshed === 'function') {
+    auth.onSessionRefreshed(handler);
+  }
+}
+
+export async function requestPasswordReset(email: string): Promise<void> {
+  const auth = await getAuth();
+  if ('requestPasswordReset' in auth && typeof auth.requestPasswordReset === 'function') {
+    return auth.requestPasswordReset(email);
+  }
+  throw new Error('Password reset is not available');
+}
+
+export async function confirmPasswordReset(email: string, code: string, newPassword: string): Promise<void> {
+  const auth = await getAuth();
+  if ('confirmPasswordReset' in auth && typeof auth.confirmPasswordReset === 'function') {
+    return auth.confirmPasswordReset(email, code, newPassword);
+  }
+  throw new Error('Password reset is not available');
 }
 
 export { SessionExpiredError } from './session.js';

--- a/apps/admin/src/infrastructure/contentApi.ts
+++ b/apps/admin/src/infrastructure/contentApi.ts
@@ -1,6 +1,13 @@
 import type { ContentDocument, Locale, SiteSettings } from '@bonae/content';
 import { config } from '../config.js';
-import { getIdToken, onSessionExpired, SessionExpiredError } from './auth.js';
+import {
+  getIdToken,
+  onSessionExpired,
+  onSessionRefreshed,
+  refreshSession,
+  SessionExpiredError,
+  type LogoutReason,
+} from './auth.js';
 
 export type ContentResource = Locale | 'settings';
 
@@ -11,23 +18,32 @@ export interface ContentResponse<T> {
   commitSha?: string;
 }
 
-let sessionExpiredCallback: (() => void) | null = null;
+let sessionExpiredCallback: ((reason: LogoutReason) => void) | null = null;
+let sessionRefreshedCallback: (() => void) | null = null;
 
-void onSessionExpired(() => {
-  sessionExpiredCallback?.();
+void onSessionExpired((reason) => {
+  sessionExpiredCallback?.(reason);
 });
 
-export function registerSessionExpiredHandler(handler: () => void): void {
+void onSessionRefreshed(() => {
+  sessionRefreshedCallback?.();
+});
+
+export function registerSessionExpiredHandler(handler: (reason: LogoutReason) => void): void {
   sessionExpiredCallback = handler;
 }
 
-async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+export function registerSessionRefreshedHandler(handler: () => void): void {
+  sessionRefreshedCallback = handler;
+}
+
+async function apiFetch<T>(path: string, init?: RequestInit, retried = false): Promise<T> {
   let token: string;
   try {
     token = await getIdToken();
   } catch (err) {
     if (err instanceof SessionExpiredError) {
-      sessionExpiredCallback?.();
+      sessionExpiredCallback?.('expired');
     }
     throw err;
   }
@@ -43,8 +59,16 @@ async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
 
   const body = (await res.json()) as T & { error?: string };
   if (!res.ok) {
+    if (res.status === 401 && !retried) {
+      const refreshed = await refreshSession();
+      if (refreshed) {
+        return apiFetch(path, init, true);
+      }
+      sessionExpiredCallback?.('expired');
+      throw new SessionExpiredError(body.error ?? 'Session expired');
+    }
     if (res.status === 401) {
-      sessionExpiredCallback?.();
+      sessionExpiredCallback?.('expired');
       throw new SessionExpiredError(body.error ?? 'Session expired');
     }
     throw new Error(body.error ?? `Request failed (${res.status})`);

--- a/apps/admin/src/infrastructure/passwordPolicy.ts
+++ b/apps/admin/src/infrastructure/passwordPolicy.ts
@@ -1,0 +1,17 @@
+const MIN_LENGTH = 12;
+
+export function validatePassword(password: string): string | null {
+  if (password.length < MIN_LENGTH) {
+    return `Password must be at least ${MIN_LENGTH} characters`;
+  }
+  if (!/[a-z]/.test(password)) {
+    return 'Password must include a lowercase letter';
+  }
+  if (!/[A-Z]/.test(password)) {
+    return 'Password must include an uppercase letter';
+  }
+  if (!/[0-9]/.test(password)) {
+    return 'Password must include a number';
+  }
+  return null;
+}

--- a/apps/admin/src/ui/Dashboard.tsx
+++ b/apps/admin/src/ui/Dashboard.tsx
@@ -13,9 +13,11 @@ type SectionId = 'hero' | 'valueProp' | 'about' | 'contact' | 'settings' | 'adva
 
 interface Props {
   onLogout: () => void;
+  sessionMessage?: string | null;
+  onDismissSessionMessage?: () => void;
 }
 
-export function Dashboard({ onLogout }: Props) {
+export function Dashboard({ onLogout, sessionMessage, onDismissSessionMessage }: Props) {
   const [locale, setLocale] = useState<Locale>('es');
   const [section, setSection] = useState<SectionId>('hero');
   const [status, setStatus] = useState<string | null>(null);
@@ -123,6 +125,16 @@ export function Dashboard({ onLogout }: Props) {
         </aside>
 
         <main className="space-y-4">
+          {sessionMessage && (
+            <div className="flex items-start justify-between gap-3 rounded-lg bg-emerald-50 px-4 py-2 text-sm text-emerald-900">
+              <p>{sessionMessage}</p>
+              {onDismissSessionMessage && (
+                <button type="button" className="shrink-0 text-emerald-700 underline" onClick={onDismissSessionMessage}>
+                  Dismiss
+                </button>
+              )}
+            </div>
+          )}
           {status && <p className="rounded-lg bg-slate-100 px-4 py-2 text-sm text-slate-700">{status}</p>}
           {contentQuery.isLoading && section !== 'settings' && <div className="card">Loading content…</div>}
           {contentQuery.error && section !== 'settings' && <div className="card text-red-700">{String(contentQuery.error)}</div>}

--- a/apps/admin/src/ui/ForgotPasswordForm.tsx
+++ b/apps/admin/src/ui/ForgotPasswordForm.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+
+interface Props {
+  onSubmit: (email: string) => Promise<void>;
+  onBack: () => void;
+  onContinue: (email: string) => void;
+}
+
+export function ForgotPasswordForm({ onSubmit, onBack, onContinue }: Props) {
+  const [email, setEmail] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [sent, setSent] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    try {
+      await onSubmit(email);
+      setSent(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to send reset code');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="card w-full max-w-md space-y-4">
+        <h1 className="text-2xl font-bold text-slate-900">Reset password</h1>
+        {sent ? (
+          <>
+            <p className="text-sm text-slate-600">
+              If an account exists for that email, a verification code has been sent. Check your inbox and enter the code on the next screen.
+            </p>
+            <button type="button" className="btn-primary w-full" onClick={() => onContinue(email)}>
+              Enter verification code
+            </button>
+          </>
+        ) : (
+          <>
+            <p className="text-sm text-slate-600">
+              Enter your administrator email. We will send a verification code if an account exists.
+            </p>
+            {error && <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+            <div>
+              <label className="field-label" htmlFor="reset-email">Email</label>
+              <input
+                id="reset-email"
+                type="email"
+                className="field-input"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                required
+              />
+            </div>
+            <button type="submit" className="btn-primary w-full" disabled={loading}>
+              {loading ? 'Sending…' : 'Send code'}
+            </button>
+            <button type="button" className="btn-secondary w-full" onClick={onBack}>
+              Back to sign in
+            </button>
+          </>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/apps/admin/src/ui/LoginForm.tsx
+++ b/apps/admin/src/ui/LoginForm.tsx
@@ -2,10 +2,12 @@ import { useState } from 'react';
 
 interface Props {
   mockMode?: boolean;
+  infoMessage?: string | null;
   onLogin: (email: string, password: string) => Promise<void>;
+  onForgotPassword?: () => void;
 }
 
-export function LoginForm({ mockMode = false, onLogin }: Props) {
+export function LoginForm({ mockMode = false, infoMessage, onLogin, onForgotPassword }: Props) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState<string | null>(null);
@@ -33,6 +35,9 @@ export function LoginForm({ mockMode = false, onLogin }: Props) {
             ? 'Local mock mode: any email and password work.'
             : 'Sign in with your administrator account.'}
         </p>
+        {infoMessage && (
+          <p className="rounded-lg bg-amber-50 p-3 text-sm text-amber-900">{infoMessage}</p>
+        )}
         {error && <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</p>}
         <div>
           <label className="field-label" htmlFor="email">Email</label>
@@ -45,6 +50,13 @@ export function LoginForm({ mockMode = false, onLogin }: Props) {
         <button type="submit" className="btn-primary w-full" disabled={loading}>
           {loading ? 'Signing in…' : 'Sign in'}
         </button>
+        {!mockMode && onForgotPassword && (
+          <p className="text-center text-sm">
+            <button type="button" className="text-dark-blue underline" onClick={onForgotPassword}>
+              Forgot password?
+            </button>
+          </p>
+        )}
       </form>
     </div>
   );

--- a/apps/admin/src/ui/ResetPasswordForm.tsx
+++ b/apps/admin/src/ui/ResetPasswordForm.tsx
@@ -1,0 +1,102 @@
+import { useState } from 'react';
+import { validatePassword } from '../infrastructure/passwordPolicy.js';
+
+interface Props {
+  email: string;
+  onSubmit: (email: string, code: string, newPassword: string) => Promise<void>;
+  onBack: () => void;
+}
+
+export function ResetPasswordForm({ email: initialEmail, onSubmit, onBack }: Props) {
+  const [email, setEmail] = useState(initialEmail);
+  const [code, setCode] = useState('');
+  const [password, setPassword] = useState('');
+  const [confirm, setConfirm] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (password !== confirm) {
+      setError('Passwords do not match');
+      return;
+    }
+    const policyError = validatePassword(password);
+    if (policyError) {
+      setError(policyError);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    try {
+      await onSubmit(email, code, password);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to reset password');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center p-4">
+      <form onSubmit={handleSubmit} className="card w-full max-w-md space-y-4">
+        <h1 className="text-2xl font-bold text-slate-900">Choose a new password</h1>
+        <p className="text-sm text-slate-600">
+          Enter the verification code from your email and a new password (12+ characters with upper, lower, and number).
+        </p>
+        {error && <p className="rounded-lg bg-red-50 p-3 text-sm text-red-700">{error}</p>}
+        <div>
+          <label className="field-label" htmlFor="reset-email-confirm">Email</label>
+          <input
+            id="reset-email-confirm"
+            type="email"
+            className="field-input"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="field-label" htmlFor="verification-code">Verification code</label>
+          <input
+            id="verification-code"
+            type="text"
+            className="field-input"
+            value={code}
+            onChange={(e) => setCode(e.target.value)}
+            required
+            autoComplete="one-time-code"
+          />
+        </div>
+        <div>
+          <label className="field-label" htmlFor="reset-password">New password</label>
+          <input
+            id="reset-password"
+            type="password"
+            className="field-input"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+          />
+        </div>
+        <div>
+          <label className="field-label" htmlFor="reset-password-confirm">Confirm password</label>
+          <input
+            id="reset-password-confirm"
+            type="password"
+            className="field-input"
+            value={confirm}
+            onChange={(e) => setConfirm(e.target.value)}
+            required
+          />
+        </div>
+        <button type="submit" className="btn-primary w-full" disabled={loading}>
+          {loading ? 'Saving…' : 'Reset password'}
+        </button>
+        <button type="button" className="btn-secondary w-full" onClick={onBack}>
+          Back to sign in
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/docs/admin-auth/README.md
+++ b/docs/admin-auth/README.md
@@ -1,0 +1,46 @@
+# Admin authentication — phased delivery
+
+Specs for session expiry UX, token refresh, password reset, and optional SES email for the content admin SPA ([`apps/admin/`](../../apps/admin/)).
+
+Platform context: [architecture.md](../architecture.md) · CI/CD: [workflows.md](../workflows.md)
+
+## Phases
+
+```mermaid
+flowchart LR
+  P1[Phase 1\nSession UX + refresh]
+  P2[Phase 2\nPassword reset]
+  P3[Phase 3\nSES email]
+  P1 --> P2
+  P2 --> P3
+  P3 -.->|optional| P3
+```
+
+| Phase | Spec | Terraform | Admin SPA | Deploy alone? |
+|-------|------|-----------|-----------|---------------|
+| 1 — Session expiry & refresh | [phase-1-session-expiry.md](./phase-1-session-expiry.md) | `cognito.tf` — refresh flow | Yes | Yes |
+| 2 — Password reset | [phase-2-password-reset.md](./phase-2-password-reset.md) | `cognito.tf` — recovery settings | Yes | Yes (Cognito default email) |
+| 3 — SES email (optional) | [phase-3-ses-email.md](./phase-3-ses-email.md) | `ses.tf` + DNS | No | Yes (infra only) |
+
+**Delivery rhythm:** one branch → one PR → deploy → update checklist below → next phase.
+
+## Status
+
+| Phase | Status | Deployed | Notes |
+|-------|--------|----------|-------|
+| 1 — Session expiry & refresh | code complete | infra yes, admin pending | Terraform applied 2026-06-29; run **Deploy admin** with `CLOUDFLARE_API_TOKEN` |
+| 2 — Password reset | code complete | infra yes, admin pending | shipped with Phase 1 in same admin build |
+| 3 — SES email (optional) | deferred | — | spec only; see [phase-3-ses-email.md](./phase-3-ses-email.md) |
+
+**Next step:** deploy admin SPA (`npm run deploy:admin` locally with Cloudflare token, or **Deploy admin** GitHub workflow on merge).
+
+## Deploy commands
+
+From repo root unless noted.
+
+| Phase | Steps |
+|-------|--------|
+| 1 & 2 | `terraform apply` in `infra/terraform/` → merge PR → **Deploy admin** (or push under `apps/admin/`) |
+| 3 | `terraform apply` → add DNS in Cloudflare → SES production access request |
+
+**Local test:** `npm run admin:dev:mock` for UI; `npm run admin:dev` with `.env` for Cognito after Phase 1.

--- a/docs/admin-auth/phase-1-session-expiry.md
+++ b/docs/admin-auth/phase-1-session-expiry.md
@@ -1,0 +1,57 @@
+# Phase 1 — Session expiry UX and token refresh
+
+## User stories
+
+- As an admin, I see a clear message when my session ends and I must sign in again.
+- As an admin, when my session is extended automatically, I am informed without being logged out.
+
+## Scope
+
+**In**
+
+- Enable Cognito refresh-token auth in Terraform
+- `refreshSession()` in auth layer; refresh-aware `getIdToken()`
+- Replace silent 30s-early logout with refresh-first timer
+- Login banner on forced expiry; dashboard banner on successful refresh
+- One retry on API 401 after refresh
+- Fix misleading `SetNewPasswordForm` copy (first-login only)
+
+**Out**
+
+- Password reset UI
+- SES / DNS
+- “Session expiring soon” warning
+
+## Terraform
+
+File: [`infra/terraform/cognito.tf`](../../infra/terraform/cognito.tf)
+
+- Add `ALLOW_REFRESH_TOKEN_AUTH` to `explicit_auth_flows`
+- Set `refresh_token_validity = 30` and `token_validity_units { refresh_token = "days" }`
+
+## App changes
+
+| File | Changes |
+|------|---------|
+| [`auth.cognito.ts`](../../apps/admin/src/infrastructure/auth.cognito.ts) | `refreshSession`, `onSessionRefreshed`, refresh-aware `getIdToken`, logout reason |
+| [`auth.mock.ts`](../../apps/admin/src/infrastructure/auth.mock.ts) | Matching stubs |
+| [`auth.ts`](../../apps/admin/src/infrastructure/auth.ts) | Facade exports |
+| [`contentApi.ts`](../../apps/admin/src/infrastructure/contentApi.ts) | Refresh + retry on 401 |
+| [`App.tsx`](../../apps/admin/src/App.tsx) | Timer logic, `logoutMessage`, session status |
+| [`LoginForm.tsx`](../../apps/admin/src/ui/LoginForm.tsx) | Optional `infoMessage` prop |
+| [`Dashboard.tsx`](../../apps/admin/src/ui/Dashboard.tsx) | Refresh banner prop |
+
+## Acceptance criteria
+
+- [ ] Manual sign-out → login screen with **no** expiry message
+- [ ] Wait past ID token expiry (or mock) → refresh succeeds → dashboard shows “session extended” banner; editing still works
+- [ ] Revoked/expired refresh token → login shows “Your session expired. Please sign in again.”
+- [ ] API call with stale token → one silent refresh + retry succeeds
+- [ ] Mock mode (`npm run admin:dev:mock`) behaves consistently
+
+## Deploy and verify
+
+1. `terraform apply` in `infra/terraform/` (cognito client update)
+2. Deploy admin SPA (**Deploy admin** workflow or push under `apps/admin/`)
+3. Sign in → leave tab open >1h → confirm refresh banner (not logout)
+4. Sign out and sign in again — regression check

--- a/docs/admin-auth/phase-2-password-reset.md
+++ b/docs/admin-auth/phase-2-password-reset.md
@@ -1,0 +1,70 @@
+# Phase 2 — Password reset (Cognito default email)
+
+Depends on [Phase 1](./phase-1-session-expiry.md).
+
+## User stories
+
+- As an admin who forgot my password, I can request a reset code by email and set a new password securely.
+- As an admin, I am not told whether an email exists in the system (enumeration protection).
+
+## Scope
+
+**In**
+
+- `account_recovery_setting { verified_email }` in Terraform
+- `requestPasswordReset` / `confirmPasswordReset` in auth layer
+- `ForgotPasswordForm` + `ResetPasswordForm` UI
+- “Forgot password?” link on login (hidden in mock mode)
+- Mock flow with fixed code `123456`
+- Client-side password policy validation (12+ chars, upper, lower, number)
+
+**Out**
+
+- SES, DNS, branded sender
+- Logged-in “change password” (future)
+
+## Terraform
+
+File: [`infra/terraform/cognito.tf`](../../infra/terraform/cognito.tf)
+
+```hcl
+account_recovery_setting {
+  recovery_mechanism {
+    name     = "verified_email"
+    priority = 1
+  }
+}
+```
+
+No `email_configuration` change — stays on Cognito default (`COGNITO_DEFAULT`, 50 emails/day per AWS account).
+
+## App changes
+
+| File | Changes |
+|------|---------|
+| Auth layer | `requestPasswordReset`, `confirmPasswordReset` |
+| `ForgotPasswordForm.tsx` | New — enter email |
+| `ResetPasswordForm.tsx` | New — code + new password |
+| `App.tsx` | Auth view: `login \| forgot \| reset \| newPassword` |
+| `LoginForm.tsx` | Forgot link + success message after reset |
+
+## Limits (Cognito default email)
+
+- Sender: `no-reply@verificationemail.com` (or similar Cognito default)
+- Quota: **50 emails/day per AWS account** (shared across pools using default email)
+- Sufficient for a small invite-only admin team
+
+## Acceptance criteria
+
+- [ ] Forgot password → generic “If an account exists, a code was sent” (same for unknown email)
+- [ ] Valid code + policy-compliant password → success → login with confirmation message
+- [ ] Invalid/expired code → clear error
+- [ ] First-login invite flow (`NEW_PASSWORD_REQUIRED`) still works
+- [ ] Mock mode: reset with code `123456` works
+
+## Deploy and verify
+
+1. `terraform apply` in `infra/terraform/`
+2. Deploy admin SPA
+3. Request reset for a real admin email → receive Cognito default email → complete reset → sign in
+4. Confirm invite-only first-login flow unchanged

--- a/docs/admin-auth/phase-3-ses-email.md
+++ b/docs/admin-auth/phase-3-ses-email.md
@@ -1,0 +1,80 @@
+# Phase 3 — SES production email (optional, deferred)
+
+Depends on [Phase 2](./phase-2-password-reset.md). **No app code changes** — Cognito sends mail; the SPA from Phase 2 is unchanged.
+
+## User stories
+
+- As an admin, password-reset emails come from `@bonaetech.com` with reliable delivery.
+- As an operator, reset emails are not capped by Cognito’s 50/day default.
+
+## Scope
+
+**In**
+
+- SES domain identity + DKIM for `bonaetech.com` in `sa-east-1`
+- IAM role for Cognito → SES
+- Cognito `email_configuration` with `EmailSendingAccount = DEVELOPER`
+- Terraform outputs for DNS records (TXT + 3 DKIM CNAMEs)
+- Runbook for Cloudflare DNS + SES production access request
+
+**Out**
+
+- Admin SPA changes
+- Dedicated IP, Mail Manager, marketing email
+
+## Planned Terraform
+
+New [`infra/terraform/ses.tf`](../../infra/terraform/ses.tf) and variables:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `ses_domain` | `bonaetech.com` | Domain to verify |
+| `cognito_from_email` | `noreply@bonaetech.com` | FROM address for Cognito |
+
+Outputs: domain verification TXT, DKIM CNAME records for Cloudflare.
+
+## DNS (Cloudflare)
+
+Additive records only — **does not affect** site routing (`bonaetech.com` A/CNAME for Pages).
+
+| Record | Purpose |
+|--------|---------|
+| 1× TXT `_amazonses.bonaetech.com` | Domain ownership |
+| 3× CNAME `*._domainkey.bonaetech.com` | DKIM signing |
+
+If business email already uses the domain (e.g. Google Workspace), **merge SPF** — do not replace:
+
+```text
+v=spf1 include:_spf.google.com include:amazonses.com ~all
+```
+
+Optional DMARC TXT helps SES production approval.
+
+## SES sandbox → production
+
+Until production access is granted:
+
+- Send only to **verified recipient** addresses in SES
+- Limit: 200 emails / 24h, 1 msg/sec
+
+After domain verification, request production access in the SES console (~24–48h). Suggested description:
+
+> Transactional password reset for invite-only admin content pool; fewer than 10 users; no marketing mail.
+
+## Acceptance criteria
+
+- [ ] DNS records added; SES domain status = verified
+- [ ] Production access granted
+- [ ] Forgot-password email arrives from `noreply@bonaetech.com` (or chosen address)
+- [ ] Phase 2 UI still works unchanged
+
+## Cost
+
+~$0 at admin scale. SES free tier (3,000 message charges/month × 12 months) starts on **first SES use** — deferring this phase preserves that clock until needed.
+
+## Deploy and verify
+
+1. `terraform apply` in `infra/terraform/`
+2. Add DNS records from Terraform outputs in Cloudflare
+3. Request SES production access
+4. Test forgot-password flow end-to-end (no admin redeploy required)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -265,6 +265,8 @@ flowchart TD
 
 ## 6. Operaciones
 
+Mejoras de autenticación del admin (sesión, refresh, reset de contraseña): [admin-auth/README.md](./admin-auth/README.md).
+
 ### Flujo de contenido
 
 Iniciar sesión → editar ES/EN → **Save draft** (confirma en `drafts/`) → **Publish** (copia `drafts/` → `published/`, dispara **Deploy site**).

--- a/infra/terraform/cognito.tf
+++ b/infra/terraform/cognito.tf
@@ -22,6 +22,13 @@ resource "aws_cognito_user_pool" "admins" {
     require_symbols   = false
     require_uppercase = true
   }
+
+  account_recovery_setting {
+    recovery_mechanism {
+      name     = "verified_email"
+      priority = 1
+    }
+  }
 }
 
 resource "aws_cognito_user_pool_client" "spa" {
@@ -32,13 +39,16 @@ resource "aws_cognito_user_pool_client" "spa" {
 
   explicit_auth_flows = [
     "ALLOW_USER_SRP_AUTH",
+    "ALLOW_REFRESH_TOKEN_AUTH",
   ]
 
   token_validity_units {
-    id_token = "hours"
+    id_token      = "hours"
+    refresh_token = "days"
   }
 
-  id_token_validity = 1
+  id_token_validity      = 1
+  refresh_token_validity = 30
 
   prevent_user_existence_errors = "ENABLED"
 }


### PR DESCRIPTION
Three pase approach to Cognito password update and refresh

Of the three phase approach, the following has been completed and is pending prod deploy:

| Area | Phase 1 | Phase 2 |
|------|---------|---------|
| **Spec/docs** | Done — [`docs/admin-auth/`](docs/admin-auth/) | Done |
| **App code** | Done — refresh, expiry messaging, API retry | Done — forgot/reset UI + auth |
| **Terraform** | Done — `ALLOW_REFRESH_TOKEN_AUTH`, 30-day refresh | Done — `account_recovery_setting` on user pool |
| **Terraform applied** | Yes (applied in prior session) | Yes (same apply) |
| **Admin SPA deployed** | **Pending** | **Pending** (same build as Phase 1) |
| **Acceptance testing** | Not verified in prod | Not verified in prod |

Everything is on branch `feature/cognito-improvements` in commit `5bfd499` (working tree clean). Per [`docs/admin-auth/README.md`](docs/admin-auth/README.md), both phases are **code complete**; only the **admin deploy** is still outstanding.

**To fully close Phases 1 & 2:**

1. Merge/deploy the admin SPA (**Deploy admin** workflow or `CLOUDFLARE_API_TOKEN=... npm run deploy:admin`).
2. Smoke-test in production:
   - Session refresh banner after ~1h idle
   - Expired session message on login
   - Forgot password → code email → reset → sign in

**Phase 3 (SES)** is intentionally not started — spec only.

If you want, I can run the admin deploy next (with your Cloudflare token) or walk through the acceptance checklist in mock mode locally.