### PR TITLE
Sección Planes: CTA de dos columnas con botón glass

### DIFF
--- a/apps/static/content/drafts/en.json
+++ b/apps/static/content/drafts/en.json
@@ -115,12 +115,9 @@
     "foundersTitle": "Founders"
   },
   "plans": {
-    "sectionBadge": "Plans",
-    "title": "Plans and pricing",
-    "subtitle": "Our prices are designed so that digitalizing your business is not a luxury but a smart investment.",
-    "cta": "Request quote",
-    "ctaSub": "Schedule a free consultation",
-    "note": "Contact us for a personalized quote based on your business needs."
+    "title": "Ready to digitalize and automate your brand?",
+    "subtitle": "The tech boost your business needs is just one click away. Get a personalized quote today.",
+    "cta": "Get a Quote Now"
   },
   "contact": {
     "sectionBadge": "Contact",

--- a/apps/static/content/drafts/es.json
+++ b/apps/static/content/drafts/es.json
@@ -115,12 +115,9 @@
     "foundersTitle": "Cofundadoras"
   },
   "plans": {
-    "sectionBadge": "Planes",
     "title": "¿Listo para digitalizar y automatizar tu marca?",
     "subtitle": "El impulso tecnológico que tu empresa necesita está a solo un clic de distancia. Obtén un presupuesto personalizado hoy mismo.",
-    "cta": "Solicitar cotización",
-    "ctaSub": "Agenda una consulta gratuita",
-    "note": "Contáctanos para una cotización personalizada según las necesidades de tu negocio."
+    "cta": "Cotiza Ahora"
   },
   "contact": {
     "sectionBadge": "Contacto",

--- a/apps/static/content/published/en.json
+++ b/apps/static/content/published/en.json
@@ -115,12 +115,9 @@
     "foundersTitle": "Founders"
   },
   "plans": {
-    "sectionBadge": "Plans",
-    "title": "Plans and pricing",
-    "subtitle": "Our prices are designed so that digitalizing your business is not a luxury but a smart investment.",
-    "cta": "Request quote",
-    "ctaSub": "Schedule a free consultation",
-    "note": "Contact us for a personalized quote based on your business needs."
+    "title": "Ready to digitalize and automate your brand?",
+    "subtitle": "The tech boost your business needs is just one click away. Get a personalized quote today.",
+    "cta": "Get a Quote Now"
   },
   "contact": {
     "sectionBadge": "Contact",

--- a/apps/static/content/published/es.json
+++ b/apps/static/content/published/es.json
@@ -115,12 +115,9 @@
     "foundersTitle": "Cofundadoras"
   },
   "plans": {
-    "sectionBadge": "Planes",
     "title": "¿Listo para digitalizar y automatizar tu marca?",
     "subtitle": "El impulso tecnológico que tu empresa necesita está a solo un clic de distancia. Obtén un presupuesto personalizado hoy mismo.",
-    "cta": "Solicitar cotización",
-    "ctaSub": "Agenda una consulta gratuita",
-    "note": "Contáctanos para una cotización personalizada según las necesidades de tu negocio."
+    "cta": "Cotiza Ahora"
   },
   "contact": {
     "sectionBadge": "Contacto",

--- a/apps/static/src/components/Plans.astro
+++ b/apps/static/src/components/Plans.astro
@@ -9,27 +9,28 @@ interface Props {
 const { t, whatsappHref } = Astro.props;
 ---
 
-<section id="planes" class="py-20 bg-dark-blue text-white">
-  <div class="max-w-6xl mx-auto px-4 sm:px-6">
-    <div class="text-center mb-14">
-      <span class="inline-block px-3 py-1 rounded-full bg-white/10 text-terracotta text-xs font-semibold uppercase tracking-wider mb-4 border border-white/20">
-        {t.plans.sectionBadge}
-      </span>
-      <h2 class="text-3xl md:text-4xl font-bold text-white mb-4">{t.plans.title}</h2>
-      <p class="text-lg text-light-blue max-w-2xl mx-auto">{t.plans.subtitle}</p>
+<section id="planes" class="plans-cta">
+  <div class="plans-cta-inner">
+    <div class="plans-cta-left">
+      <div class="plans-cta-copy">
+        <h2 class="plans-cta-title">{t.plans.title}</h2>
+        <p class="plans-cta-subtitle">{t.plans.subtitle}</p>
+      </div>
     </div>
-
-    <p class="text-center text-light-blue text-sm mb-6">{t.plans.note}</p>
-    <div class="flex flex-col sm:flex-row gap-4 justify-center items-center">
-      <a href={whatsappHref} target="_blank" rel="noopener noreferrer" class="btn-whatsapp">
-        <svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
-          <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/>
-        </svg>
-        {t.plans.cta}
-      </a>
-      <a href="#contacto" class="inline-flex items-center gap-2 px-6 py-3 rounded-lg border-2 border-white/40 text-white font-semibold hover:bg-white/10 transition-colors">
-        {t.plans.ctaSub}
-      </a>
+    <div class="plans-cta-right">
+      <div class="plans-cta-glass">
+        <a
+          href={whatsappHref}
+          target="_blank"
+          rel="noopener noreferrer"
+          class="plans-cta-button"
+        >
+          <svg class="plans-cta-whatsapp-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
+            <path d="M17.472 14.382c-.297-.149-1.758-.867-2.03-.967-.273-.099-.471-.148-.67.15-.197.297-.767.966-.94 1.164-.173.199-.347.223-.644.075-.297-.15-1.255-.463-2.39-1.475-.883-.788-1.48-1.761-1.653-2.059-.173-.297-.018-.458.13-.606.134-.133.298-.347.446-.52.149-.174.198-.298.298-.497.099-.198.05-.371-.025-.52-.075-.149-.669-1.612-.916-2.207-.242-.579-.487-.5-.669-.51-.173-.008-.371-.01-.57-.01-.198 0-.52.074-.792.372-.272.297-1.04 1.016-1.04 2.479 0 1.462 1.065 2.875 1.213 3.074.149.198 2.096 3.2 5.077 4.487.709.306 1.262.489 1.694.625.712.227 1.36.195 1.871.118.571-.085 1.758-.719 2.006-1.413.248-.694.248-1.289.173-1.413-.074-.124-.272-.198-.57-.347m-5.421 7.403h-.004a9.87 9.87 0 01-5.031-1.378l-.361-.214-3.741.982.998-3.648-.235-.374a9.86 9.86 0 01-1.51-5.26c.001-5.45 4.436-9.884 9.888-9.884 2.64 0 5.122 1.03 6.988 2.898a9.825 9.825 0 012.893 6.994c-.003 5.45-4.437 9.884-9.885 9.884m8.413-18.297A11.815 11.815 0 0012.05 0C5.495 0 .16 5.335.157 11.892c0 2.096.547 4.142 1.588 5.945L.057 24l6.305-1.654a11.882 11.882 0 005.683 1.448h.005c6.554 0 11.89-5.335 11.893-11.893a11.821 11.821 0 00-3.48-8.413z"/>
+          </svg>
+          <span class="plans-cta-button-label">{t.plans.cta}</span>
+        </a>
+      </div>
     </div>
   </div>
 </section>

--- a/apps/static/src/styles/global.css
+++ b/apps/static/src/styles/global.css
@@ -136,4 +136,139 @@
       @apply mt-4;
     }
   }
+
+  .plans-cta {
+    @apply relative overflow-hidden text-white;
+    background: linear-gradient(
+      90deg,
+      #ff6f61 0%,
+      #ff6f61 58%,
+      #ff8276 78%,
+      #ff8a7e 90%,
+      #ff9185 100%
+    );
+  }
+
+  .plans-cta-inner {
+    @apply mx-auto grid min-h-[280px] max-w-6xl items-center gap-10 px-4 py-12 sm:px-6 lg:grid-cols-[1.35fr_0.65fr] lg:gap-12 lg:py-14;
+  }
+
+  .plans-cta-left {
+    @apply flex items-center justify-start;
+  }
+
+  .plans-cta-right {
+    @apply flex items-center justify-center lg:justify-end;
+  }
+
+  .plans-cta-copy {
+    @apply w-full;
+  }
+
+  .plans-cta-title {
+    @apply font-bold text-white mb-6 leading-tight tracking-tight;
+    font-size: clamp(1.35rem, 2.2vw, 2.25rem);
+  }
+
+  @media (min-width: 1024px) {
+    .plans-cta-title {
+      white-space: nowrap;
+    }
+  }
+
+  .plans-cta-subtitle {
+    @apply w-full text-white/95;
+    font-size: clamp(1rem, 1.35vw, 1.125rem);
+    line-height: 1.75;
+    max-width: none;
+  }
+
+  .plans-cta-glass {
+    @apply relative inline-block rounded-3xl;
+    padding: 3.19rem 2.7rem;
+    overflow: visible;
+    background: rgba(255, 255, 255, 0.48);
+    backdrop-filter: blur(20px);
+    -webkit-backdrop-filter: blur(20px);
+    border: 2.5px solid rgba(255, 255, 255, 0.58);
+    box-shadow:
+      inset 4px 4px 7px rgba(255, 255, 255, 0.78),
+      inset -4px -4px 7px rgba(140, 48, 38, 0.1),
+      inset 2px 2px 0 rgba(255, 255, 255, 0.72),
+      inset -2px -2px 0 rgba(100, 35, 28, 0.08),
+      0 16px 40px rgba(0, 0, 0, 0.07);
+  }
+
+  .plans-cta-glass::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: inherit;
+    padding: 2.5px;
+    background: linear-gradient(
+      145deg,
+      rgba(255, 255, 255, 0.92) 0%,
+      rgba(255, 255, 255, 0.35) 42%,
+      rgba(110, 38, 30, 0.12) 58%,
+      rgba(255, 255, 255, 0.55) 100%
+    );
+    -webkit-mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    mask:
+      linear-gradient(#fff 0 0) content-box,
+      linear-gradient(#fff 0 0);
+    -webkit-mask-composite: xor;
+    mask-composite: exclude;
+    pointer-events: none;
+  }
+
+  @media (min-width: 640px) {
+    .plans-cta-glass {
+      padding: 3.64rem 3.3rem;
+    }
+  }
+
+  .plans-cta-button {
+    @apply relative inline-flex items-center gap-3 font-semibold text-white no-underline;
+    min-width: min(100%, 16rem);
+    padding: 1rem 2rem;
+    border-radius: 9999px;
+    font-size: 1.125rem;
+    line-height: 1.25;
+    white-space: nowrap;
+    background: linear-gradient(
+      90deg,
+      #ff6f61 0%,
+      #ff6f61 32%,
+      rgba(255, 111, 97, 0.72) 58%,
+      rgba(255, 255, 255, 0.22) 100%
+    );
+    box-shadow: 0 8px 24px rgba(180, 50, 40, 0.28);
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+  }
+
+  .plans-cta-whatsapp-icon {
+    @apply w-5 h-5 shrink-0;
+  }
+
+  .plans-cta-button-label {
+    @apply relative z-[1];
+  }
+
+  .plans-cta-button:hover {
+    transform: scale(1.03);
+    box-shadow: 0 12px 28px rgba(180, 50, 40, 0.34);
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .plans-cta-button {
+      transition: none;
+    }
+
+    .plans-cta-button:hover {
+      transform: none;
+      box-shadow: 0 8px 24px rgba(180, 50, 40, 0.28);
+    }
+  }
 }

--- a/docs/plans-cta-manual.md
+++ b/docs/plans-cta-manual.md
@@ -1,0 +1,122 @@
+# Sección Planes → CTA de dos columnas — manual de cambio
+
+La sección `#planes` dejó de ser un bloque centrado con badge "PLANES" y pasó a ser un **call to action en dos columnas**: copy a la izquierda y botón de WhatsApp a la derecha.
+
+## Resumen visual
+
+| Antes | Después |
+|-------|---------|
+| Badge "Planes" + título + subtítulo centrados | Sin badge |
+| Nota inferior + 2 botones (WhatsApp + contacto) | Solo botón WhatsApp |
+| Layout en una columna centrada | Grid 2 columnas (stack en móvil) |
+
+**Columna izquierda:** `title` + `subtitle`  
+**Columna derecha:** botón WhatsApp (`cta`) — mismo enlace que el resto del sitio vía `whatsappHref`
+
+---
+
+## Archivos modificados (7)
+
+| # | Archivo | Qué cambió |
+|---|---------|------------|
+| 1 | `packages/content/src/schema.ts` | Esquema `plans` reducido a `title`, `subtitle`, `cta` (eliminados `sectionBadge`, `ctaSub`, `note`) |
+| 2 | `apps/static/src/components/Plans.astro` | Layout 2 columnas; sin badge; un solo botón WhatsApp |
+| 3 | `apps/static/content/published/es.json` | Copy ES + `cta`: "Cotiza Ahora" |
+| 4 | `apps/static/content/published/en.json` | Copy EN traducido |
+| 5 | `apps/static/content/drafts/es.json` | Igual que published (admin mock) |
+| 6 | `apps/static/content/drafts/en.json` | Igual que published (admin mock) |
+| 7 | `docs/plans-cta-manual.md` | Este manual |
+
+**No se modificaron:** `index.astro`, `en/index.astro`, Header, Footer, admin forms (Planes solo se edita vía **Advanced JSON** en el admin).
+
+---
+
+## Campos JSON (`plans`)
+
+```json
+"plans": {
+  "title": "¿Listo para digitalizar y automatizar tu marca?",
+  "subtitle": "El impulso tecnológico que tu empresa necesita está a solo un clic de distancia. Obtén un presupuesto personalizado hoy mismo.",
+  "cta": "Cotiza Ahora"
+}
+```
+
+| Campo | Uso |
+|-------|-----|
+| `title` | Título columna izquierda (h2) |
+| `subtitle` | Párrafo bajo el título |
+| `cta` | Texto del botón WhatsApp |
+
+El enlace del botón **no** va en JSON: se genera con `whatsappHrefFor(t)` desde `settings.json` (`whatsappNumber` + mensaje de contacto).
+
+---
+
+## Cómo editar el contenido
+
+### Admin mock
+```bash
+npm run admin:dev:mock
+```
+1. **Advanced JSON** → busca el objeto `"plans"`.
+2. Edita `title`, `subtitle`, `cta` en ES y EN.
+3. Guarda draft en ambos idiomas → **Publish site**.
+
+### JSON directo
+- Borradores: `apps/static/content/drafts/es.json` y `en.json`
+- Sitio en build: `apps/static/content/published/es.json` y `en.json`
+
+---
+
+## Diseño actual (CTA coral con degradado)
+
+Degradado horizontal suave, sin banda sólida:
+
+| Parada | Color | Rol |
+|--------|-------|-----|
+| 0%–58% | `#FF6F61` | Coral sólido (zona de texto) |
+| 78% | `#FF8276` | Transición |
+| 90% | `#FF8A7E` | Transición |
+| 100% | `#FF9185` | Tono final |
+
+Dos columnas asimétricas en desktop (`1.35fr / 0.65fr`). El copy ocupa todo el ancho de la columna izquierda.
+
+Estilos en `apps/static/src/styles/global.css` (clases `.plans-cta*`).
+
+---
+
+## Cómo editar el diseño
+
+| Qué | Dónde |
+|-----|--------|
+| Estructura 2 columnas | `apps/static/src/components/Plans.astro` + `.plans-cta-inner` en `global.css` |
+| Degradado y tipografía CTA | Clases `.plans-cta*` en `apps/static/src/styles/global.css` |
+| Validación de campos | `packages/content/src/schema.ts` — objeto `plans` |
+
+Tras cambiar el esquema:
+```bash
+npm run content:build
+npm run content:validate:drafts
+```
+
+---
+
+## Probar en local
+
+```bash
+npm run dev
+```
+Abre http://localhost:4321/ y baja a la sección `#planes` (antes del contacto).
+
+Si no ves los cambios de estilo:
+
+1. Detén el servidor (`Ctrl+C`) y vuelve a ejecutar `npm run dev`.
+2. Confirma que la URL es **http://localhost:4321/** (no el sitio desplegado en producción).
+3. Hard reload: **Ctrl + Shift + R** (o vacía caché del navegador).
+4. Alternativa directa sin Turbo: `npm run dev -w bonae-static`.
+
+---
+
+## Revertir o ampliar
+
+- **Segundo botón** (p. ej. enlace a `#contacto`): añade campo en schema + JSON + markup en `Plans.astro`.
+- **Badge de sección**: añade `sectionBadge` al schema y un `<span>` en la columna izquierda (como en ValueProp).

--- a/packages/content/src/schema.ts
+++ b/packages/content/src/schema.ts
@@ -74,12 +74,9 @@ export const contentDocumentSchema = z.object({
   }),
 
   plans: z.object({
-    sectionBadge: z.string().min(1),
     title: z.string().min(1),
     subtitle: z.string().min(1),
     cta: z.string().min(1),
-    ctaSub: z.string().min(1),
-    note: z.string().min(1),
   }),
 
   contact: z.object({


### PR DESCRIPTION
## Summary
- Reemplaza la sección Planes por un CTA en dos columnas: copy a la izquierda y botón WhatsApp a la derecha dentro de un recuadro glass con bisel.
- Simplifica el esquema plans a 	itle, subtitle y cta; actualiza contenido ES/EN y estilos con degradado coral (#FF6F61 → #FF9185).
- Añade docs/plans-cta-manual.md con guía de edición y diseño.

## Test plan
- [ ] 
pm run dev y revisar #planes en http://localhost:4321/
- [ ] Verificar botón WhatsApp, recuadro glass y degradado de fondo
- [ ] 
pm run content:build && npm run content:validate:drafts
- [ ] Revisar versión EN en /en/

Made with [Cursor](https://cursor.com)